### PR TITLE
Add software method to enter bootloader

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,7 @@ int main(void) {
             post_reset_sequence |= UART1_Read() << (i * 8);
         }
     }
-    bool const magic_match = reset_sequence == 0xDECAFBAD;
+    bool const magic_match = post_reset_sequence == 0xDECAFBAD;
 
     // If the boot pin is grounded (BOOT button pressed on v6), stay in boot.
     BOOT_PIN_SetDigitalOutput();

--- a/src/main.c
+++ b/src/main.c
@@ -6,10 +6,10 @@
  * (RC5) is grounded, the device will stay in bootloader mode even if an
  * application exists. While in bootloader mode, a new application can be
  * flashed with the Unified Bootloader Host Application, or a similar tool.
- * 
+ *
  * From PSLab V6 revision onwards, there is a push button attached to BOOT pin
  * with a label `BOOT`. Holding this button down at power up or when clicking on
- * `Read Device Settings` in Unified Bootloader application will switch from  
+ * `Read Device Settings` in Unified Bootloader application will switch from
  * main application to bootloader mode where one can flash a new firmware.
  */
 
@@ -41,16 +41,14 @@ int main(void) {
     // If BOOT is grounded or no application is detected, stay in bootloader.
     if (BOOT_PIN_GetValue() && BOOT_Verify()) {
         BOOT_StartApplication();
-    } else {
-        uint16_t i = 0;
+    }
 
-        while (1) {
-            // Monitor serial bus for commands, e.g. flashing new application.
-            BOOT_ProcessCommand();
+    for (uint16_t i = 0; 1; ++i) {
+        // Monitor serial bus for commands, e.g. flashing new application.
+        BOOT_ProcessCommand();
 
-            // Blink system LED while in bootloader mode.
-            if (!i++) STATUS_LED_Toggle();
-        }
+        // Blink system LED while in bootloader mode.
+        if (!i) STATUS_LED_Toggle();
     }
 
     return 1;


### PR DESCRIPTION
This PR makes it possible to enter bootloader mode via software, without pressing the BOOT button. By sending the magic number `0xDECAFBAD` to the PSLab soon after reboot (within about 500 ms), the PSLab will stay in bootloader mode. This is useful for several reasons:

- During firmware development, it's annoying to have to press the BOOT and RESET buttons all the time
- The PSLab v5 has not buttons, so entering bootloader currently requires [short-circuiting two pins on the MCU](https://github.com/fossasia/pslab-firmware#entering-bootloader-mode-on-pslab-v5)
- Being able to drop to bootloader with a command makes it possible to do firmware development remotely, e.g. by SSH:ing into a remote machine connected to a PSLab