### PR TITLE
Fix incorrect address check in CalculateChecksum (close #6)

### DIFF
--- a/src/mcc_generated_files/boot/boot_process.c
+++ b/src/mcc_generated_files/boot/boot_process.c
@@ -442,7 +442,7 @@ static enum BOOT_COMMAND_RESULT CalculateChecksum(void)
 
     memcpy(&response, commandArray, sizeof(struct CMD_STRUCT_0));
     
-    if ( IsLegalRange(pCommand->address, pCommand->address+pCommand->dataLength-1))
+    if ( IsLegalRange(pCommand->address, pCommand->address+pCommand->dataLength / 2))
     {
         for (count = 0; count < pCommand->dataLength; count += 4)
         {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the address range check in the `CalculateChecksum` function to prevent potential memory errors.