### PR TITLE
chore: update upload-artifact action

### DIFF
--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -46,7 +46,7 @@ jobs:
                 make
 
             - name: Publish build files
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v7
               with:
                 name: production-file
                 path: build/pslab-bootloader.hex


### PR DESCRIPTION
Fixes #12

## Summary by Sourcery

CI:
- Bump actions/upload-artifact in the main-builder workflow from v3 to v7 for publishing build artifacts.